### PR TITLE
allow a local install of nodemon and to pick whatever port in non https mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,12 @@ const server = ($$.ssl.enabled
     : require('http').createServer(app)
 );
 
-const port = $$.ssl.enabled ? 443 : 80;
-console.info(`Listening on port: ${port}`);
-server.listen(port);
+const MIAKI_PORT = process.env['MIAKI_PORT']
+const port = $$.ssl.enabled ? 443 : MIAKI_PORT || 80;
+server.listen(port, () => {
+    console.info(`Listening on port: ${server.address().port}`);
+});
+
 
 app.use(function(req, res, next) {
     res.header("Access-Control-Allow-Origin", "*");

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "dependencies": {
     "express": "^4.17.1",
     "pm2": "^3.5.1"
+  },
+  "devDependencies": {
+    "nodemon": "^1.19.1"
   }
 }


### PR DESCRIPTION
Just small suggestions after playing with the thing for a couple minutes =)

`nodemon`, albeit useful, is not ubiquitous and should probably be installed with other dependencies and not require guesswork from users, this PR should prevent the thing from crashing outright just because nodemon isn't globally installed on the machine that'll run it. 

Also, it is generally considered good practice to not rely on globally installed stuff as you cannot know what is installed on any random machine that will attempt to run your app, nor on the actual version of the thing (for example, I am probably running a different `nodemon` version than you are, and even though it is generally okay-ish at first, things can get complicated once these "implicitly required" libs change too much : if i see an error message requiring me to install lib <whatever>, I'm probably not going to bother and install the latest one and pray that it works as at this point I have no clue which version to use and cannot get the info)

port choice takes advantage of the fact that `0` tells express to pick any random available port on the system